### PR TITLE
Web scraper

### DIFF
--- a/liacs_calendar/__init__.py
+++ b/liacs_calendar/__init__.py
@@ -1,8 +1,6 @@
-__PROGRAM_DESCRIPTION__ = ("Convert the LIACS xls schedule to an iCal for "
-                          "easy importation into your personal calendar.\n"
-                          "If no courses are provided, the whole xls will be "
-                          "converted into an iCal file. \n"
-                          "")
+__PROGRAM_DESCRIPTION__ = """Convert the LIACS xls schedule to an iCal for easy importation into your personal calendar.\n
+                          
+                          """
 import sys
 
 if sys.version_info < (3, 0):

--- a/liacs_calendar/cli.py
+++ b/liacs_calendar/cli.py
@@ -1,5 +1,5 @@
-from . import (read_excel, get_course_entries, get_course_list, write_schedule, create_ical, create_calendar, __PROGRAM_DESCRIPTION__)
-
+from . import (read_excel, get_course_entries, get_course_list, write_schedule, create_ical, create_calendar, __PROGRAM_DESCRIPTION__, web_scraper)
+from termcolor import cprint
 def cli():
     import argparse
     import sys
@@ -11,11 +11,14 @@ def cli():
     arg_parser.add_argument("--courses", "-c", help="Single course name, or "
                             "comma separated list of courses", type=str,
                             required=False)
-    arg_parser.add_argument("--list-courses", "-l", help="List courses", 
+    arg_parser.add_argument("--list-courses", "-l", help="List courses (when you want to provide courses manually, e.g. a CSV-file, use this list)", 
                             action="store_true", dest="dolist", required=False)
     arg_parser.add_argument("--output", "-o", help="Output filename", type=str,
                             required=False, default="schedule.ical")
-
+    arg_parser.add_argument("--study-programme", "-s", help="Study programme (for automatic web scraping). Format: {Major-name}_{Academic-year-start}_{Year-you-are-in}_{Semester}", 
+                            type=str, required=False, dest="study_programme")
+    arg_parser.add_argument("--list-programmes", "-L", help="List all available study programmes", action="store_true", dest="list_programmes", required=False)
+    arg_parser.add_argument("--no-cache", "-N", help="Deletes the current cache and performs all study programme requests without caching", action="store_true", dest="no_cache", required=False)
     if len(sys.argv) < 2:
         arg_parser.print_help()
         exit(-1)
@@ -58,4 +61,27 @@ def cli():
 
         write_schedule(outputfile, cal)
 
-        
+    if args.study_programme:
+        try:
+            parts = args.study_programme.split("_")
+            print(parts)
+            major = parts[0]
+            uni_year = int(parts[1])
+            year = int(parts[2])
+            semester = int(parts[3])
+        except:
+            cprint("ERROR: Invalid format for study programme. Should be {Major-name}_{Academic-year-start}_{Year-you-are-in}_{Semester}", "red")
+            print("Example:  `--study-programme Informatica_2019_2_1` for all courses of bachelor Informatica in the academic year 2019-2020, for a 2nd year student, first semester.")
+            exit(-1)
+        result = None
+        if args.no_cache:
+            print("Deleting current cache, not using any cached results, and not caching any results")
+            web_scraper.delete_disk_caches_for_function("scrape_courses_cached")
+            result = web_scraper.scrape_courses(major, uni_year, year, semester)
+        else:
+            result = web_scraper.scrape_courses_cached(major, uni_year, year, semester)
+        print(result)
+    if args.list_programmes:
+        print("Available study programmes:")
+        for programme in web_scraper.MAJOR_NAMES.keys():
+            print(programme)

--- a/liacs_calendar/web_scraper.py
+++ b/liacs_calendar/web_scraper.py
@@ -1,0 +1,88 @@
+import requests, time
+from termcolor import cprint
+from pprint import pprint
+from bs4 import BeautifulSoup, Tag
+from cache_to_disk import cache_to_disk, delete_disk_caches_for_function
+
+CACHE_VALID_DAYS = 1
+URL_BASE = "https://studiegids.universiteitleiden.nl/studies/"
+MAJOR_URI = {
+  "Informatica": "6901/informatica",
+  "Bioinformatica": "7889/bioinformatica",
+  "Informatica en Economie": "7887/informatica-economie",
+}
+
+
+def course_in_semester(table_row: Tag, semester: int) -> bool:
+  """Check whether the course of this table_row is in the selected semester
+  """
+  blocks = table_row.find_all("span", {"class", "block"})
+  for block in blocks:
+    classes = block["class"]
+    if semester == 1 and ("block-1" in classes or "block-2" in classes):
+      if "block-on" in classes:
+        return True
+    elif semester == 2 and ("block-3" in classes or "block-4" in classes): 
+      if "block-on" in classes:
+        return True
+  return False
+
+@cache_to_disk(CACHE_VALID_DAYS)
+def scrape_courses_cached(major: str, year: int, semester: int, silent=False):
+  """Same as scrape_courses, but results are cached to the disk for CACHE_VALID_DAYS days.
+  """
+  if not silent:
+    print("Caching results of requests")
+  return scrape_courses(major, year, semester)
+
+def remove_courses_cache():
+  """Remove cached results of scrape_courses_cached
+  """
+  delete_disk_caches_for_function("scrape_courses")
+
+def scrape_courses(major: str, year: int, semester: int) -> dict:
+  """Return a dictionary of all courses of a specific major, year, and semester.
+  Example for scrape_courses('Informatica', 1, 1):
+  {
+    'Continue Wiskunde 1': '4031CW103',
+    'Fundamentals of Digital Systems Design': '4031FDSD6',
+    'Fundamentele Informatica 1': '4031FINF1',
+    'Linear Algebra for Computer Scientists 1': '4031LACS1',
+    'Oriëntatie Informatica': '4031ORINC',
+    'Programmeermethoden': '4031PRGR6',
+    'Studying and Presenting': '4031STPEV'
+  }
+  """
+  if major not in MAJOR_URI:
+    raise ValueError(f"{major} is not in the list of majors")
+  courses_and_codes = {}
+  try:
+    full_page = requests.get(URL_BASE + MAJOR_URI[major])
+  except requests.ConnectionError:
+    cprint("ERROR: Could not obtain course page. Are you connected to the internet?", 'red')
+    raise
+  if full_page.status_code == 404:
+    cprint("ERROR: Course page URL was invalid. The website may have been updated, which breaks this tool :(", 'red')
+    raise Exception("404: Page not found")
+  soup = BeautifulSoup(full_page.content, 'html.parser')
+  content_tables = soup("section", {"class": "tab"})
+  # Table of courses for 'year'
+  current_table = content_tables[year-1].find("tbody")
+  all_rows = current_table.findAll("tr")
+  for tr in all_rows:
+    time.sleep(0.5)
+    course = str(tr.find("a").string)
+    link = tr.find("a")["href"]
+    if course_in_semester(tr, semester):
+      link = tr.find("a")["href"]
+      print(f"Requesting page for {course}...")
+      course_page = requests.get(link)
+      course_soup = BeautifulSoup(course_page.content, 'html.parser')
+      course_code = str(course_soup.find("aside").findAll("dd")[2].string)
+      courses_and_codes[course] = course_code
+  return courses_and_codes
+
+if __name__ == "__main__":
+
+  result = scrape_courses("Informatica", 1, 1)
+  pprint(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 icalendar==4.0.4
+requests==2.18.4
 xlrd==1.2.0
+beautifulsoup4==4.8.2
+cache_to_disk==0.0.4
+termcolor==1.1.0


### PR DESCRIPTION
Web scraper die voor een bepaald studie, studiejaar en semester alle courses met course code geeft toegevoegd.
Nieuwe commando's en flags:
- `-L, --list-programmes`  
Geeft lijst van alle studies beschikbaar voor web scraping.
- `-s <studie_jaar_semester>, --study-programme <studie_jaar_semester>`
Geeft een dictionary `{ "course_name": "course_code" }` voor aangegeven studie, jaar, semester.
Voorbeeld: `python3 liacs_calendar.py <excel_file> -s informatica_1_2` voor alle courses van Informatica, voor een eerstejaarsstudent in het tweede semester.
Deze kan hopelijk gebruikt worden om alle relevante courses in het Excel-bestand te vinden.
- `-N, --no-cache`
Resultaten voor `-s` worden standaard gecached naar de harde schijf. De cache is op het moment 1 dag geldig. Met `-N` wordt de cache niet gebruikt voor `-s`.
- `-D, --delete-cache`
Verwijder alle gecachte resultaten van `-s`.

TODO:
- Beter errors opvangen (Niet-bestaand semester / jaar geeft een standaard Exception).
